### PR TITLE
Update installation manual to fix problems with conan and cmake and repository name

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,43 +37,13 @@ To do this, please open an ew terminal and execute the following steps
 sudo apt install --yes gpg wget 
 ```
 
-2. Add the signing key of the kitware cmake repository
+2. Install cmake 3.23.5 by running the script:
 
 ```bash
-wget -O - https://apt.kitware.com/keys/kitware-archive-latest.asc 2>/dev/null | gpg --dearmor - | sudo tee /usr/share/keyrings/kitware-archive-keyring.gpg >/dev/null
+./install-cmake.sh
 ```
 
-3. Add the repository to apt sources
-
-```bash
-echo 'deb [signed-by=/usr/share/keyrings/kitware-archive-keyring.gpg] https://apt.kitware.com/ubuntu/ focal main' | sudo tee /etc/apt/sources.list.d/kitware.list >/dev/null
-```
-
-4. Update the apt package database
-
-```bash
-sudo apt update
-```
-
-5. Remove the signing key used to install the repository, as it is no longer needed
-
-```bash
-sudo rm /usr/share/keyrings/kitware-archive-keyring.gpg
-```
-
-6. Install kitware keyring, to ensure you are able to update cmake when future versions are released
-
-```bash
-sudo apt install --yes kitware-archive-keyring
-```
-
-7. Update cmake
-
-```bash
-sudo apt install cmake
-```
-
-8. Verify that you have an updated version, by running the following command
+3. Verify that you have the right version, by running the following command
 
 ```bash
 cmake --version
@@ -82,10 +52,10 @@ cmake --version
 The output of the above command should be something like:
 
 ```
-cmake version 3.23.1
+cmake version 3.23.5
 ```
 
-A version of CMake newer than 3.21 is required to compile the simulator.
+A version of CMake newer than 3.21 and older than 4.0 is required to compile the simulator.
 
 ### Install Qt
 
@@ -265,7 +235,7 @@ sudo apt install --yes python3-pip
 2. Install conan
 
 ```bash
-sudo pip3 install --upgrade conan
+sudo pip3 install conan==1.60.2
 ```
 
 3. Execute the following command to check that conan was installed
@@ -277,7 +247,7 @@ conan --version
 The output of this command should be similar to
 
 ```bash
-Conan version 1.47.0
+Conan version 1.60.2
 ```
 
 ### Add the ProVANT Simulator Environment Variables

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ sudo apt install --yes gpg wget
 2. Install cmake 3.23.5 by running the script:
 
 ```bash
+wget https://raw.githubusercontent.com/ProVANT-Project/ProVANT_Simulator/refs/heads/main/install-cmake.sh
+sudo chmod +x install-cmake.sh
 ./install-cmake.sh
 ```
 

--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ cd $HOME/catkin_ws/src
 2. Clone the ProVANT Simulator git repository
 
 ```bash
-git clone https://github.com/Guiraffo/ProVANT-Simulator.git
+git clone https://github.com/ProVANT-Project/ProVANT_Simulator.git
 ```
 
 ### Install Conan
@@ -266,13 +266,13 @@ Go to the end of this file, and paste the following lines:
 
 ```bash
 # ProVANT Simulator Environment Variables
-export TILT_PROJECT=$HOME/catkin_ws/src/ProVANT-Simulator/
+export TILT_PROJECT=$HOME/catkin_ws/src/ProVANT_Simulator/
 export PROVANT_ROS=$HOME/catkin_ws/src/
 export DIR_ROS=$HOME/catkin_ws/
 export TILT_STRATEGIES=$HOME/catkin_ws/devel/lib/
-export TILT_MATLAB=$HOME/catkin_ws/src/ProVANT-Simulator/source/Structure/Matlab/
-export PROVANT_DATABASE=$HOME/catkin_ws/src/ProVANT-Simulator/source/Database/
-export GAZEBO_MODEL_PATH=$HOME/catkin_ws/src/ProVANT-Simulator/source/Database/models/
+export TILT_MATLAB=$HOME/catkin_ws/src/ProVANT_Simulator/source/Structure/Matlab/
+export PROVANT_DATABASE=$HOME/catkin_ws/src/ProVANT_Simulator/source/Database/
+export GAZEBO_MODEL_PATH=$HOME/catkin_ws/src/ProVANT_Simulator/source/Database/models/
 ```
 
 Save the file in gedit, and close your terminal.
@@ -304,7 +304,7 @@ To compile and install the GUI, please open a terminal and execute the following
 1. Open the ProVANT Simulator source folder
 
 ```bash
-cd $HOME/catkin_ws/src/ProVANT-Simulator/source
+cd $HOME/catkin_ws/src/ProVANT_Simulator/source
 ```
 
 2. Create a build folder for the GUI
@@ -334,7 +334,7 @@ make
 6. Install the GUI
 
 ```bash
-sudo ln -sf $HOME/catkin_ws/src/ProVANT-Simulator/source/build/GUI /usr/local/bin/provant_gui
+sudo ln -sf $HOME/catkin_ws/src/ProVANT_Simulator/source/build/GUI /usr/local/bin/provant_gui
 ```
 
 7. Check that the GUI is opening correctly

--- a/install-cmake.sh
+++ b/install-cmake.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+wget https://cmake.org/files/v3.23/cmake-3.23.5.tar.gz
+tar -xvf cmake-3.23.5.tar.gz
+cd cmake-3.23.5
+
+./bootstrap --system-curl
+make -j$(nproc)
+make install
+
+cd ..
+rm -rf cmake-3.23.5
+

--- a/install-cmake.sh
+++ b/install-cmake.sh
@@ -6,7 +6,7 @@ cd cmake-3.23.5
 
 ./bootstrap --system-curl
 make -j$(nproc)
-make install
+sudo make install
 
 cd ..
 rm -rf cmake-3.23.5

--- a/provant_simulator_plugins/provant_simulator_camera_plugins/CMakeLists.txt
+++ b/provant_simulator_plugins/provant_simulator_camera_plugins/CMakeLists.txt
@@ -28,9 +28,15 @@ find_package(
              roscpp
 )
 
+include(FetchContent)
+FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG        v1.16.0 # Or another desired version/tag
+    )
+FetchContent_MakeAvailable(spdlog)
+
 find_package(OpenCV REQUIRED)
-run_conan(conanfile.txt)
-find_package(spdlog REQUIRED)
 find_package(
   Qt5
   COMPONENTS Core Widgets
@@ -60,9 +66,6 @@ catkin_package(
   OpenCV
 )
 
-add_definitions(${spdlog_libspdlog_DEFINITIONS})
-add_compile_definitions("SPDLOG_FMT_EXTERNAL")
-
 include_directories(
   include
   ${catkin_INCLUDE_DIRS}
@@ -70,7 +73,6 @@ include_directories(
   ${OpenCV_INCLUDE_DIRS}
   ${Boost_INCLUDE_DIR}
   ${Qt5Core_INCLUDE_DIRS}
-  ${spdlog_INCLUDE_DIRS}
 )
 
 add_library(
@@ -84,7 +86,7 @@ target_link_libraries(
   ${OpenCV_LIBRARIES}
   ${GAZEBO_LIBRARIES}
   ${OGRE_LIBRARIES}
-  ${spdlog_LIBRARIES}
+  spdlog::spdlog
 )
 set_property(TARGET provant_camera_recorder PROPERTY POSITION_INDEPENDENT_CODE ON)
 

--- a/provant_simulator_plugins/provant_simulator_camera_plugins/conanfile.txt
+++ b/provant_simulator_plugins/provant_simulator_camera_plugins/conanfile.txt
@@ -1,7 +1,0 @@
-[requires]
-spdlog/1.9.2
-
-[generators]
-cmake_find_package
-
-[options]

--- a/provant_simulator_plugins/provant_simulator_gui_plugins/conan.txt
+++ b/provant_simulator_plugins/provant_simulator_gui_plugins/conan.txt
@@ -1,5 +1,0 @@
-[requires]
-ms-gsl/3.1.0
-
-[generators]
-cmake_find_package

--- a/provant_simulator_plugins/provant_simulator_plugins/CMakeLists.txt
+++ b/provant_simulator_plugins/provant_simulator_plugins/CMakeLists.txt
@@ -11,6 +11,13 @@ if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
 endif()
 
+include(FetchContent)
+FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG        v1.16.0 # Or another desired version/tag
+    )
+FetchContent_MakeAvailable(spdlog)
 find_package(
   catkin REQUIRED
   COMPONENTS gazebo_ros
@@ -28,13 +35,6 @@ find_package(
 find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED)
 
-run_conan(conanfile.txt)
-find_package(spdlog REQUIRED)
-find_package(fmt REQUIRED)
-
-add_definitions(${spdlog_libspdlog_DEFINITIONS})
-add_compile_definitions("SPDLOG_FMT_EXTERNAL")
-
 # Declare the list of plugin libraries that will be built
 set(PLUGIN_LIBRARIES
     provant_config_plugin
@@ -51,7 +51,6 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
-  ${spdlog_INCLUDE_DIRS}
   ${fmt_INCLUDE_DIRS}
   include
 )
@@ -119,7 +118,7 @@ target_link_libraries(
   provant_position_logger_plugin
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
-  ${spdlog_LIBRARIES}
+  spdlog::spdlog
   ${fmt_LIBRARIES}
 )
 
@@ -132,7 +131,6 @@ target_link_libraries(
   provant_lidar_closest_obj_plugin
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
-  ${spdlog_LIBRARIES}
   ${fmt_LIBRARIES}
   GpuRayPlugin
 )

--- a/provant_simulator_plugins/provant_simulator_plugins/conanfile.txt
+++ b/provant_simulator_plugins/provant_simulator_plugins/conanfile.txt
@@ -1,7 +1,0 @@
-[requires]
-spdlog/1.9.2
-
-[generators]
-cmake_find_package
-
-[options]

--- a/provant_simulator_tests/provant_gz_sphere_tests/CMakeLists.txt
+++ b/provant_simulator_tests/provant_gz_sphere_tests/CMakeLists.txt
@@ -14,6 +14,12 @@ FetchContent_Declare(
         GIT_TAG        v1.16.0 # Or another desired version/tag
     )
 FetchContent_MakeAvailable(spdlog)
+FetchContent_Declare(
+    fmt
+    GIT_REPOSITORY https://github.com/fmtlib/fmt.git
+    GIT_TAG 11.2.0 # Or a more recent version tag
+)
+FetchContent_MakeAvailable(fmt)
 find_package(
   catkin REQUIRED
   COMPONENTS gazebo_ros
@@ -24,8 +30,6 @@ find_package(
 )
 find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED)
-
-find_package(fmt REQUIRED)
 
 set(PLUGIN_LIBRARIES
     provant_test_apply_force_plugin

--- a/provant_simulator_tests/provant_gz_sphere_tests/CMakeLists.txt
+++ b/provant_simulator_tests/provant_gz_sphere_tests/CMakeLists.txt
@@ -7,6 +7,13 @@ project(provant_gz_sphere_tests)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include(FetchContent)
+FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG        v1.16.0 # Or another desired version/tag
+    )
+FetchContent_MakeAvailable(spdlog)
 find_package(
   catkin REQUIRED
   COMPONENTS gazebo_ros
@@ -18,12 +25,7 @@ find_package(
 find_package(gazebo REQUIRED)
 find_package(Boost REQUIRED)
 
-run_conan(conanfile.txt)
-find_package(spdlog REQUIRED)
 find_package(fmt REQUIRED)
-
-add_definitions(${spdlog_libspdlog_DEFINITIONS})
-add_compile_definitions("SPDLOG_FMT_EXTERNAL")
 
 set(PLUGIN_LIBRARIES
     provant_test_apply_force_plugin
@@ -51,7 +53,6 @@ include_directories(
   ${Boost_INCLUDE_DIRS}
   ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
-  ${spdlog_INCLUDE_DIRS}
   ${fmt_INCLUDE_DIRS}
   include
 )
@@ -65,6 +66,7 @@ target_link_libraries(
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
   ${Boost_LIBRARIES}
+  spdlog::spdlog
 )
 
 add_library(provant_test_set_force_once_plugin src/set_force_once/set_force_once.cpp)
@@ -74,6 +76,7 @@ target_link_libraries(
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
   ${Boost_LIBRARIES}
+  spdlog::spdlog
 )
 
 add_library(provant_test_apply_force_plugin src/apply_force_multiple/apply_force_multiple.cpp)
@@ -83,6 +86,7 @@ target_link_libraries(
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
   ${Boost_LIBRARIES}
+  spdlog::spdlog
 )
 
 add_library(provant_test_set_force_plugin src/set_force/set_force.cpp)
@@ -92,6 +96,7 @@ target_link_libraries(
   ${catkin_LIBRARIES}
   ${GAZEBO_LIBRARIES}
   ${Boost_LIBRARIES}
+  spdlog::spdlog
 )
 
 install(

--- a/provant_simulator_tests/provant_gz_sphere_tests/conanfile.txt
+++ b/provant_simulator_tests/provant_gz_sphere_tests/conanfile.txt
@@ -1,7 +1,0 @@
-[requires]
-spdlog/1.9.2
-
-[generators]
-cmake_find_package
-
-[options]

--- a/provant_simulator_utils/provant_simulator_log_utils/CMakeLists.txt
+++ b/provant_simulator_utils/provant_simulator_log_utils/CMakeLists.txt
@@ -8,12 +8,22 @@ project(provant_simulator_log_utils CXX)
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
+include(FetchContent)
+FetchContent_Declare(
+        spdlog
+        GIT_REPOSITORY https://github.com/gabime/spdlog.git
+        GIT_TAG        v1.16.0 # Or another desired version/tag
+    )
+FetchContent_MakeAvailable(spdlog)
+# FetchContent_Declare(
+#         googletest
+#         GIT_REPOSITORY https://github.com/google/googletest.git
+#         GIT_TAG        release-1.11.0 # Or a specific commit hash
+# )
+# FetchContent_MakeAvailable(googletest)
 find_package(catkin REQUIRED COMPONENTS gazebo_ros provant_simulator_cmake
                                         roscpp)
 
-run_conan(conanfile.txt)
-find_package(spdlog REQUIRED)
-find_package(GTest REQUIRED)
 find_package(gazebo REQUIRED)
 
 catkin_package(
@@ -29,17 +39,14 @@ catkin_package(
   # DEPENDS system_lib
 )
 
-add_definitions(${spdlog_libspdlog_DEFINITIONS})
-add_compile_definitions("SPDLOG_FMT_EXTERNAL")
-
 include_directories(
-  include ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS} ${spdlog_INCLUDE_DIRS}
+  include ${catkin_INCLUDE_DIRS} ${GAZEBO_INCLUDE_DIRS}
   ${fmt_INCLUDE_DIRS} ${GTest_gtest_INCLUDE_DIRS})
 
 add_library(provant_ros_log STATIC src/roslog/rossink.cpp)
 add_dependencies(provant_ros_log ${${PROJECT_NAME}_EXPORTED_TARGETS}
                  ${catkin_EXPORTED_TARGETS})
-target_link_libraries(provant_ros_log ${catkin_LIBRARIES} ${spdlog_LIBRARIES}
+target_link_libraries(provant_ros_log ${catkin_LIBRARIES} spdlog::spdlog
                       ${fmt_LIBRARIES})
 set_property(TARGET provant_ros_log PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -47,7 +54,7 @@ add_library(provant_gz_log STATIC src/gzlog/gzlog.cpp)
 add_dependencies(provant_gz_log ${${PROJECT_NAME}_EXPORTED_TARGETS}
                  ${catkin_EXPORTED_TARGETS})
 target_link_libraries(provant_gz_log ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES}
-                      ${spdlog_LIBRARIES} ${fmt_LIBRARIES})
+                      spdlog::spdlog ${fmt_LIBRARIES})
 set_property(TARGET provant_gz_log PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 add_library(provant_logtest_plugin src/test_plugin/logtestplugin.cpp)
@@ -55,7 +62,7 @@ add_dependencies(provant_logtest_plugin ${${PROJECT_NAME}_EXPORTED_TARGETS}
                  ${catkin_EXPORTED_TARGETS})
 target_link_libraries(
   provant_logtest_plugin PUBLIC spdlog::spdlog provant_gz_log)
-target_link_libraries(provant_logtest_plugin PRIVATE ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+  target_link_libraries(provant_logtest_plugin PRIVATE ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} spdlog::spdlog)
 
 install(
   TARGETS provant_gz_log provant_logtest_plugin provant_ros_log
@@ -70,26 +77,7 @@ install(
   PATTERN "*.h"
   PATTERN ".svn" EXCLUDE)
 
-# Install spdlog
-# install(TARGETS ${spdlog_LIBRARIES}
-#   ARCHIVE DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
-#   RUNTIME DESTINATION ${CATKIN_GLOBAL_BIN_DESTINATION}
-# )
-  
-# install(
-#   DIRECTORY ${spdlog_INCLUDE_DIRS}/spdlog/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}/../
-#   FILES_MATCHING 
-#   PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-# print_imported_targets()
-# dump_cmake_variables(spdlog)
-
 if(CATKIN_ENABLE_TESTING)
-  # catkin_add_gtest(test_${PROJECT_NAME} tests/test.cpp WORKING_DIRECTORY
   # ${PROJECT_SOURCE_DIR}/tests ) target_link_libraries(test_${PROJECT_NAME}
   # ${catkin_LIBRARIES} ${PROJECT_NAME} )
 endif()

--- a/provant_simulator_utils/provant_simulator_log_utils/conanfile.txt
+++ b/provant_simulator_utils/provant_simulator_log_utils/conanfile.txt
@@ -1,8 +1,0 @@
-[requires]
-spdlog/1.9.2
-gtest/cci.20210126
-
-[generators]
-cmake_find_package
-
-[options]

--- a/provant_simulator_utils/provant_simulator_sdf_parser/CMakeLists.txt
+++ b/provant_simulator_utils/provant_simulator_sdf_parser/CMakeLists.txt
@@ -3,7 +3,13 @@
 
 cmake_minimum_required(VERSION 3.14)
 project(provant_simulator_sdf_parser)
-
+include(FetchContent)
+FetchContent_Declare(GSL
+    GIT_REPOSITORY "https://github.com/microsoft/GSL"
+    GIT_TAG "v4.2.0"
+    GIT_SHALLOW ON
+)
+FetchContent_MakeAvailable(GSL)
 # Silence warning about unquoted variables in find_boost
 if(POLICY CMP0054)
   cmake_policy(SET CMP0054 NEW)
@@ -16,7 +22,6 @@ find_package(catkin REQUIRED COMPONENTS gazebo_ros provant_simulator_cmake prova
 find_package(gazebo REQUIRED)
 
 # Provide the Microsoft C++ Guidelines Support Library
-run_conan(${CMAKE_CURRENT_SOURCE_DIR}/conan.txt)
 dump_cmake_variables(CONAN)
 
 catkin_package(
@@ -34,12 +39,11 @@ include_directories(
   include
   ${catkin_INCLUDE_DIRS}
   ${GAZEBO_INCLUDE_DIRS}
-  ${CONAN_INCLUDE_DIRS_MS-GSL}
 )
 
 add_library(${PROJECT_NAME} STATIC src/sdf_parser.cpp src/sdf_status.cpp)
 add_dependencies(${PROJECT_NAME} ${${PROJECT_NAME}_EXPORTED_TARGETS} ${catkin_EXPORTED_TARGETS})
-target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES})
+target_link_libraries(${PROJECT_NAME} ${catkin_LIBRARIES} ${GAZEBO_LIBRARIES} Microsoft.GSL::GSL)
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 install(
@@ -69,6 +73,7 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES}
     ${PROJECT_NAME}
     ${GAZEBO_LIBRARIES}
+    Microsoft.GSL::GSL
   )
   catkin_add_gtest(
     test_sdf_status
@@ -81,5 +86,6 @@ if(CATKIN_ENABLE_TESTING)
     ${catkin_LIBRARIES}
     ${PROJECT_NAME}
     ${GAZEBO_LIBRARIES}
+    Microsoft.GSL::GSL
   )
 endif()

--- a/provant_simulator_utils/provant_simulator_sdf_parser/conan.txt
+++ b/provant_simulator_utils/provant_simulator_sdf_parser/conan.txt
@@ -1,5 +1,0 @@
-[requires]
-ms-gsl/3.1.0
-
-[generators]
-cmake_find_package


### PR DESCRIPTION
# Description

    Update installation manual to correct problems with versions of cmake and conan, and fix the name of the repository


# Changes

    - pin conan version to 1.60.2. conan was giving an error at version 1.40.7 and above 2.0
    - change cmake version to 3.23.5, since cmake from the ppa is 4.0 and gives an error for any CMakelists.txt with required version below 3.5.
    - Change ProVANT-Simultor to ProVANT_Simulator in the README


Installation step changes have been tested by Aclecio.

# Checklist

- [x] This code compiles without any error or significative warning on the
latest version of the development branch;
- [x] This code follows the code style of ROS with attention to all the relevant
exceptions of the ProVANT Simulator project;
- [x] The contributed source code is adequately commented using doxygen and
normal comments when necessary;
- [x] All of the submitted code is able to comply with the MIT open source 
license used by the ProVANT simulator project, and you vouch that no code was
copied from projects with incompatible licenses or from proprietary software;
- [x] You forfeit any copyright claims of the contributed elements to the 
ProVANT Simulator project, and agree with the distribution of the contributed
source code under the terms of the MIT open source license.

**Please note that when making a contribution to the project, you accept the terms outlined in the preceding checklist**
